### PR TITLE
feat: Signed URL 업로드 추가 (#293)

### DIFF
--- a/src/api/dto/files.dto.ts
+++ b/src/api/dto/files.dto.ts
@@ -9,9 +9,31 @@ export interface UploadFileRequestDto {
   file: File;
   title: string;
 }
+
+export interface CreateUploadUrlRequestDto {
+  purpose: 'presentation_file';
+  contentType: string;
+  size: number;
+  originalFilename: string;
+  title?: string;
+}
+
+export interface CreateUploadUrlResponseDto {
+  objectKey: string;
+  uploadUrl: string;
+  expiresAt: string;
+  uploadToken: string;
+}
+
+export interface CompleteUploadRequestDto {
+  objectKey: string;
+  uploadToken: string;
+}
 /**
  * 파일 업로드 응답 DTO
  */
 export interface UploadFileResponseDto {
   projectId: string;
 }
+
+export type CompleteUploadResponseDto = UploadFileResponseDto;

--- a/src/api/endpoints/files.ts
+++ b/src/api/endpoints/files.ts
@@ -1,9 +1,15 @@
+import axios from 'axios';
 import type { AxiosProgressEvent } from 'axios';
 
 import type { ApiResponse } from '@/types';
 
 import { apiClient } from '../client';
-import type { UploadFileRequestDto, UploadFileResponseDto } from '../dto/files.dto';
+import type {
+  CompleteUploadRequestDto,
+  CompleteUploadResponseDto,
+  CreateUploadUrlRequestDto,
+  CreateUploadUrlResponseDto,
+} from '../dto/files.dto';
 
 type UploadOptions = {
   onUploadProgress?: (event: AxiosProgressEvent) => void;
@@ -11,28 +17,48 @@ type UploadOptions = {
 };
 
 export const filesApi = {
-  // POST /files/upload - 파일 업로드(발표자료/발표영상)
-  uploadFile: async (data: UploadFileRequestDto, options?: UploadOptions) => {
-    if (!(data.file instanceof File)) {
-      throw new Error('유효한 파일이 아닙니다.');
-    }
-
-    const formData = new FormData();
-    formData.append('file', data.file);
-    if (data.title) {
-      formData.append('title', data.title);
-    }
-
-    const response = await apiClient.post<ApiResponse<UploadFileResponseDto>>(
-      '/files/upload',
-      formData,
+  createUploadUrl: async (
+    data: CreateUploadUrlRequestDto,
+    options?: UploadOptions,
+  ): Promise<ApiResponse<CreateUploadUrlResponseDto>> => {
+    const response = await apiClient.post<ApiResponse<CreateUploadUrlResponseDto>>(
+      '/files/upload-url',
+      data,
       {
-        onUploadProgress: options?.onUploadProgress,
         signal: options?.signal,
-        headers: { 'Content-Type': undefined },
       },
     );
+    return response.data;
+  },
 
+  uploadToSignedUrl: async (
+    args: {
+      uploadUrl: string;
+      file: File;
+      contentType: string;
+    },
+    options?: UploadOptions,
+  ): Promise<void> => {
+    await axios.put(args.uploadUrl, args.file, {
+      headers: {
+        'Content-Type': args.contentType,
+      },
+      signal: options?.signal,
+      onUploadProgress: options?.onUploadProgress,
+    });
+  },
+
+  completeUpload: async (
+    data: CompleteUploadRequestDto,
+    options?: UploadOptions,
+  ): Promise<ApiResponse<CompleteUploadResponseDto>> => {
+    const response = await apiClient.post<ApiResponse<CompleteUploadResponseDto>>(
+      '/files/upload-complete',
+      data,
+      {
+        signal: options?.signal,
+      },
+    );
     return response.data;
   },
 };

--- a/src/hooks/useUploadFile.test.ts
+++ b/src/hooks/useUploadFile.test.ts
@@ -1,0 +1,189 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { AxiosProgressEvent } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { filesApi } from '@/api/endpoints/files';
+import { sessionApi } from '@/api/endpoints/session';
+import { useAuthStore } from '@/stores/authStore';
+
+import { useUploadFile } from './useUploadFile';
+
+vi.mock('@/api/endpoints/files', () => ({
+  filesApi: {
+    createUploadUrl: vi.fn(),
+    uploadToSignedUrl: vi.fn(),
+    completeUpload: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/endpoints/session', () => ({
+  sessionApi: {
+    createAnonymousSession: vi.fn(),
+  },
+}));
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: {
+    getState: vi.fn(),
+  },
+}));
+
+const mockFilesApi = vi.mocked(filesApi);
+const mockSessionApi = vi.mocked(sessionApi);
+const mockGetAuthState = vi.mocked(useAuthStore.getState);
+
+describe('useUploadFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthState.mockReturnValue({
+      accessToken: 'token',
+      user: { id: '1' },
+    } as never);
+  });
+
+  it('uploads through signed URL flow and completes with done state', async () => {
+    const file = new File(['pdf-content'], 'deck.pdf', { type: 'application/pdf' });
+
+    mockFilesApi.createUploadUrl.mockResolvedValue({
+      resultType: 'SUCCESS',
+      error: null,
+      success: {
+        objectKey: 'dev/upload/temp/deck.pdf',
+        uploadUrl: 'https://storage.googleapis.com/mock-signed-url',
+        expiresAt: '2026-02-18T00:00:00.000Z',
+        uploadToken: 'upload-token',
+      },
+    });
+
+    mockFilesApi.uploadToSignedUrl.mockImplementation(async (_args, options) => {
+      options?.onUploadProgress?.({
+        loaded: 100,
+        total: 100,
+      } as AxiosProgressEvent);
+    });
+
+    mockFilesApi.completeUpload.mockResolvedValue({
+      resultType: 'SUCCESS',
+      error: null,
+      success: { projectId: '123' },
+    });
+
+    const { result } = renderHook(() => useUploadFile());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.uploadFile({ file, title: file.name });
+    });
+
+    expect(response).toEqual({
+      resultType: 'SUCCESS',
+      error: null,
+      success: { projectId: '123' },
+    });
+    expect(mockFilesApi.createUploadUrl).toHaveBeenCalledWith(
+      {
+        purpose: 'presentation_file',
+        contentType: 'application/pdf',
+        size: file.size,
+        originalFilename: 'deck.pdf',
+        title: 'deck.pdf',
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(mockFilesApi.uploadToSignedUrl).toHaveBeenCalledTimes(1);
+    expect(mockFilesApi.completeUpload).toHaveBeenCalledWith(
+      {
+        objectKey: 'dev/upload/temp/deck.pdf',
+        uploadToken: 'upload-token',
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(mockSessionApi.createAnonymousSession).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.progress).toEqual({ percentage: 100, currentStep: 'done' });
+    });
+  });
+
+  it('returns null and sets error when upload-url request fails', async () => {
+    const file = new File(['pdf-content'], 'deck.pdf', { type: 'application/pdf' });
+
+    mockFilesApi.createUploadUrl.mockResolvedValue({
+      resultType: 'FAILURE',
+      error: {
+        errorCode: 'F001',
+        reason: '업로드 URL 발급 실패',
+      },
+      success: null,
+    });
+
+    const { result } = renderHook(() => useUploadFile());
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.uploadFile({ file, title: file.name });
+    });
+
+    expect(response).toBeNull();
+    expect(mockFilesApi.uploadToSignedUrl).not.toHaveBeenCalled();
+    expect(mockFilesApi.completeUpload).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.error).toBe('업로드 URL 발급 실패');
+      expect(result.current.progress).toEqual({ percentage: 0, currentStep: 'preparing' });
+    });
+  });
+
+  it('returns null and resets state on cancel', async () => {
+    const file = new File(['pdf-content'], 'deck.pdf', { type: 'application/pdf' });
+
+    mockFilesApi.createUploadUrl.mockResolvedValue({
+      resultType: 'SUCCESS',
+      error: null,
+      success: {
+        objectKey: 'dev/upload/temp/deck.pdf',
+        uploadUrl: 'https://storage.googleapis.com/mock-signed-url',
+        expiresAt: '2026-02-18T00:00:00.000Z',
+        uploadToken: 'upload-token',
+      },
+    });
+
+    mockFilesApi.uploadToSignedUrl.mockImplementation(
+      (_args, options) =>
+        new Promise<void>((_resolve, reject) => {
+          const signal = options?.signal;
+          if (signal?.aborted) {
+            reject(new DOMException('Aborted', 'AbortError'));
+            return;
+          }
+
+          signal?.addEventListener(
+            'abort',
+            () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const { result } = renderHook(() => useUploadFile());
+
+    let uploadPromise: Promise<unknown>;
+    await act(async () => {
+      uploadPromise = result.current.uploadFile({ file, title: file.name });
+    });
+
+    act(() => {
+      result.current.cancelUpload();
+    });
+
+    let response: unknown;
+    await act(async () => {
+      response = await uploadPromise!;
+    });
+
+    expect(response).toBeNull();
+    expect(result.current.isUploading).toBe(false);
+    expect(result.current.progress).toEqual({ percentage: 0, currentStep: 'preparing' });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useUploadFile.ts
+++ b/src/hooks/useUploadFile.ts
@@ -81,31 +81,67 @@ export function useUploadFile() {
         // 업로드 시작
         setProgress({ ...initialProgress, currentStep: 'uploading' });
 
-        // 업로드 요청
-        const startResponse = await filesApi.uploadFile(data, {
-          signal: controller.signal,
-          onUploadProgress: (e: AxiosProgressEvent) => {
-            const total = e.total ?? 0;
-            if (!total) return;
-
-            const percentage = Math.round((e.loaded * 100) / total);
-
-            // 전송이 거의 끝났을 때
-            setProgress({
-              percentage,
-              currentStep: percentage >= 100 ? 'finishing' : 'uploading',
-            });
+        const uploadUrlResponse = await filesApi.createUploadUrl(
+          {
+            purpose: 'presentation_file',
+            contentType: data.file.type,
+            size: data.file.size,
+            originalFilename: data.file.name,
+            title: data.title,
           },
-        });
+          { signal: controller.signal },
+        );
 
-        // 응답 검증
-        if (startResponse.resultType === 'FAILURE') {
-          throw new Error(startResponse.error?.reason ?? '파일 업로드에 실패했어요.');
+        if (uploadUrlResponse.resultType === 'FAILURE') {
+          throw new Error(uploadUrlResponse.error?.reason ?? '업로드 URL 발급에 실패했어요.');
+        }
+
+        await filesApi.uploadToSignedUrl(
+          {
+            uploadUrl: uploadUrlResponse.success.uploadUrl,
+            file: data.file,
+            contentType: data.file.type,
+          },
+          {
+            signal: controller.signal,
+            onUploadProgress: (e: AxiosProgressEvent) => {
+              const total = e.total ?? 0;
+              if (!total) return;
+
+              const percentage = Math.round((e.loaded * 100) / total);
+
+              // 전송이 거의 끝났을 때
+              setProgress({
+                percentage,
+                currentStep: percentage >= 100 ? 'finishing' : 'uploading',
+              });
+            },
+          },
+        );
+
+        setProgress({ percentage: 100, currentStep: 'finishing' });
+
+        const completeResponse = await filesApi.completeUpload(
+          {
+            objectKey: uploadUrlResponse.success.objectKey,
+            uploadToken: uploadUrlResponse.success.uploadToken,
+          },
+          { signal: controller.signal },
+        );
+
+        if (completeResponse.resultType === 'FAILURE') {
+          throw new Error(completeResponse.error?.reason ?? '파일 업로드 완료 처리에 실패했어요.');
         }
 
         // 완료 처리
         setProgress({ percentage: 100, currentStep: 'done' });
-        return startResponse;
+        return {
+          resultType: 'SUCCESS',
+          error: null,
+          success: {
+            projectId: completeResponse.success.projectId,
+          },
+        };
       } catch (err: unknown) {
         if (
           (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') ||


### PR DESCRIPTION
## Summary
- 기존 `POST /files/upload` 멀티파트 업로드 의존을 제거하고, `upload-url -> GCS PUT -> upload-complete` 3단계 업로드 플로우로 전환
- `filesApi`에 `createUploadUrl`, `uploadToSignedUrl`, `completeUpload`를 추가하고 `useUploadFile`을 Signed URL 직접 업로드 구조로 변경
- 업로드 진행 단계(`preparing -> uploading -> finishing -> done`)는 유지하면서 완료 응답 계약(`projectId`)을 기존 UI 흐름과 호환되게 유지
- 파일 업로드 DTO 확장(`CreateUploadUrlRequest/Response`, `CompleteUploadRequest/Response`) 및 훅 단위 테스트(`useUploadFile.test.ts`) 추가

## Test plan
- [x] `npm run test -- src/hooks/useUploadFile.test.ts`
- [x] `npm run type-check`
- [x] 로컬 환경에서 PDF/PPTX 업로드 실동작 확인
- [x] GCS CORS 설정 후 브라우저 preflight/PUT 성공 확인
