### PR TITLE
fix: improve script autosave reliability and responsiveness (#304)

### DIFF
--- a/src/components/slide/SlideWorkspace.tsx
+++ b/src/components/slide/SlideWorkspace.tsx
@@ -7,10 +7,10 @@
  * - ScriptBox 접힘 상태를 관리하고 SlideViewer에 전달
  * - Zustand store로 슬라이드 상태 관리
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { SLIDE_MAX_WIDTH } from '@/constants/layout';
-import { useSlideActions, useSlideId } from '@/hooks';
+import { useSlideActions, useSlideId, useSlideScript } from '@/hooks';
 import { useScript } from '@/hooks/queries/useScript';
 import { useSlideCommentsLoader } from '@/hooks/useSlideCommentsLoader';
 import type { SlideListItem } from '@/types/slide';
@@ -27,7 +27,10 @@ export default function SlideWorkspace({ slide, isLoading }: SlideWorkspaceProps
   const [isScriptCollapsed, setIsScriptCollapsed] = useState(false);
   const { initSlide, updateScript, updateSlide } = useSlideActions();
   const slideId = useSlideId();
+  const script = useSlideScript();
   const { data: scriptData } = useScript(slideId);
+  const lastSyncedSlideIdRef = useRef<string>('');
+  const lastSyncedScriptRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!slide) return;
@@ -45,10 +48,28 @@ export default function SlideWorkspace({ slide, isLoading }: SlideWorkspaceProps
   useSlideCommentsLoader(slide?.slideId);
 
   useEffect(() => {
-    if (scriptData) {
-      updateScript(scriptData.scriptText);
+    if (lastSyncedSlideIdRef.current !== slideId) {
+      lastSyncedSlideIdRef.current = slideId;
+      lastSyncedScriptRef.current = null;
     }
-  }, [scriptData, updateScript]);
+  }, [slideId]);
+
+  useEffect(() => {
+    if (!scriptData) return;
+
+    const serverScript = scriptData.scriptText;
+    const hasSyncedOnce = lastSyncedScriptRef.current !== null;
+    const hasLocalEditAfterSync = hasSyncedOnce && script !== lastSyncedScriptRef.current;
+
+    // 로컬 편집이 있는 동안에는 서버 응답으로 덮어쓰지 않습니다.
+    if (hasLocalEditAfterSync && script !== serverScript) return;
+
+    if (script !== serverScript) {
+      updateScript(serverScript);
+    }
+
+    lastSyncedScriptRef.current = serverScript;
+  }, [script, scriptData, updateScript]);
 
   return (
     <div className="relative h-full min-h-0 flex flex-col pb-[clamp(12rem,30vh,20rem)] md:pb-0">

--- a/src/components/slide/script/ScriptBoxContent.tsx
+++ b/src/components/slide/script/ScriptBoxContent.tsx
@@ -4,14 +4,14 @@
  *
  * 슬라이드 대본을 입력하는 텍스트 영역입니다.
  * Zustand store를 통해 대본을 읽고 업데이트하며,
- * 500ms debounce로 자동저장됩니다.
+ * debounce로 자동저장됩니다.
  */
 import { useAutoSaveScript, useSlideActions, useSlideScript } from '@/hooks';
 
 export default function ScriptBoxContent() {
   const script = useSlideScript();
   const { updateScript } = useSlideActions();
-  const { autoSave } = useAutoSaveScript();
+  const { autoSave, flushSave } = useAutoSaveScript();
 
   const handleChange = (value: string) => {
     updateScript(value);
@@ -23,6 +23,7 @@ export default function ScriptBoxContent() {
       <textarea
         value={script}
         onChange={(e) => handleChange(e.target.value)}
+        onBlur={flushSave}
         placeholder="슬라이드 대본을 입력하세요..."
         aria-label="슬라이드 대본"
         className="h-full w-full resize-none border-none bg-transparent text-base leading-relaxed text-gray-800 outline-none placeholder:text-gray-600 overflow-y-auto"

--- a/src/hooks/queries/useScript.ts
+++ b/src/hooks/queries/useScript.ts
@@ -38,8 +38,12 @@ export function useUpdateScript() {
     mutationFn: ({ slideId, data }: { slideId: string; data: UpdateScriptRequestDto }) =>
       updateScript(slideId, data),
 
-    onSuccess: (_, { slideId }) => {
-      void queryClient.invalidateQueries({ queryKey: queryKeys.scripts.detail(slideId) });
+    onMutate: async ({ slideId }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.scripts.detail(slideId) });
+    },
+
+    onSuccess: (savedScript, { slideId }) => {
+      queryClient.setQueryData(queryKeys.scripts.detail(slideId), savedScript);
       void queryClient.invalidateQueries({ queryKey: queryKeys.scripts.versions(slideId) });
     },
   });

--- a/src/hooks/useAutoSaveScript.test.ts
+++ b/src/hooks/useAutoSaveScript.test.ts
@@ -7,6 +7,17 @@ import { showToast } from '@/utils/toast';
 
 import { useAutoSaveScript } from './useAutoSaveScript';
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 // Mock useUpdateScript
 const mockMutateAsync = vi.fn();
 vi.mock('@/hooks/queries/useScript', () => ({
@@ -122,5 +133,117 @@ describe('useAutoSaveScript', () => {
       vi.advanceTimersByTime(500);
     });
     expect(mockMutateAsync).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it('retries pending script when browser comes back online', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce({});
+    const { result } = renderHook(() => useAutoSaveScript());
+
+    act(() => {
+      result.current.autoSave('offline draft');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      await Promise.resolve();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(2);
+    expect(mockMutateAsync).toHaveBeenLastCalledWith({
+      slideId: 'slide-1',
+      data: { script: 'offline draft' },
+    });
+  });
+
+  it('flushes pending script immediately on online event before debounce delay', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    const { result } = renderHook(() => useAutoSaveScript());
+
+    act(() => {
+      result.current.autoSave('quick draft');
+    });
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      await Promise.resolve();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      slideId: 'slide-1',
+      data: { script: 'quick draft' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushSave saves immediately without waiting for debounce', async () => {
+    mockMutateAsync.mockResolvedValue({});
+    const { result } = renderHook(() => useAutoSaveScript());
+
+    act(() => {
+      result.current.autoSave('blur draft');
+    });
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.flushSave();
+      await Promise.resolve();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      slideId: 'slide-1',
+      data: { script: 'blur draft' },
+    });
+  });
+
+  it('saves newer pending script after in-flight save completes', async () => {
+    const firstSave = createDeferred<object>();
+    mockMutateAsync.mockImplementationOnce(() => firstSave.promise).mockResolvedValueOnce({});
+
+    const { result } = renderHook(() => useAutoSaveScript());
+
+    act(() => {
+      result.current.autoSave('first');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenNthCalledWith(1, {
+      slideId: 'slide-1',
+      data: { script: 'first' },
+    });
+
+    act(() => {
+      result.current.autoSave('second');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstSave.resolve({});
+      await Promise.resolve();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(2);
+    expect(mockMutateAsync).toHaveBeenNthCalledWith(2, {
+      slideId: 'slide-1',
+      data: { script: 'second' },
+    });
   });
 });

--- a/src/hooks/useAutoSaveScript.ts
+++ b/src/hooks/useAutoSaveScript.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useUpdateScript } from '@/hooks/queries/useScript';
 import { showToast } from '@/utils/toast';
@@ -6,15 +6,15 @@ import { showToast } from '@/utils/toast';
 import { useDebouncedCallback } from './useDebounce';
 import { useSlideId } from './useSlideSelectors';
 
-const AUTOSAVE_DELAY = 500;
+const AUTOSAVE_DELAY = 300;
 
 /**
  * 대본 자동저장 훅
  *
- * 500ms debounce로 대본을 자동저장하고 Toast로 피드백을 제공합니다.
+ * 300ms debounce로 대본을 자동저장하고 Toast로 피드백을 제공합니다.
  *
  * @example
- * const { autoSave, isSaving } = useAutoSaveScript();
+ * const { autoSave, flushSave, isSaving } = useAutoSaveScript();
  *
  * const handleChange = (value: string) => {
  *   updateScript(value);
@@ -25,29 +25,91 @@ export function useAutoSaveScript() {
   const slideId = useSlideId();
   const { mutateAsync, isPending } = useUpdateScript();
   const lastSavedRef = useRef<string>('');
+  const pendingScriptRef = useRef<string | null>(null);
+  const isSavingRef = useRef(false);
+  const activeSlideIdRef = useRef(slideId);
 
-  const saveScript = useCallback(
-    async (script: string) => {
+  const flushPendingSave = useCallback(async () => {
+    if (!slideId || isSavingRef.current) return;
+
+    const scriptToSave = pendingScriptRef.current;
+
+    // 저장할 내용이 없거나 이미 서버에 반영된 값이면 스킵
+    if (scriptToSave === null || scriptToSave === lastSavedRef.current) return;
+
+    isSavingRef.current = true;
+    let saveSucceeded = false;
+    try {
+      await mutateAsync({ slideId, data: { script: scriptToSave } });
+
+      if (activeSlideIdRef.current !== slideId) return;
+
+      saveSucceeded = true;
+      lastSavedRef.current = scriptToSave;
+
+      if (pendingScriptRef.current === scriptToSave) {
+        pendingScriptRef.current = null;
+        showToast.success('대본을 저장했습니다.', '작성 내용이 자동으로 반영되었습니다.');
+      }
+    } catch {
+      showToast.error('대본을 저장하지 못했습니다.', '다시 시도해주세요.');
+    } finally {
+      isSavingRef.current = false;
+    }
+
+    const nextPending = pendingScriptRef.current;
+    if (saveSucceeded && nextPending !== null && nextPending !== lastSavedRef.current) {
+      void flushPendingSave();
+    }
+  }, [slideId, mutateAsync]);
+
+  const scheduleFlush = useDebouncedCallback(() => {
+    void flushPendingSave();
+  }, AUTOSAVE_DELAY);
+
+  const autoSave = useCallback(
+    (script: string) => {
       if (!slideId) return;
 
-      // 이전 저장 값과 동일하면 스킵
-      if (lastSavedRef.current === script) return;
+      pendingScriptRef.current = script;
 
-      try {
-        await mutateAsync({ slideId, data: { script } });
-        lastSavedRef.current = script;
-        showToast.success('대본을 저장했습니다.', '작성 내용이 자동으로 반영되었습니다.');
-      } catch {
-        showToast.error('대본을 저장하지 못했습니다.', '다시 시도해주세요.');
+      // 이전 저장 값과 동일하면 스킵
+      if (lastSavedRef.current === script) {
+        pendingScriptRef.current = null;
+        return;
       }
+
+      scheduleFlush();
     },
-    [slideId, mutateAsync],
+    [slideId, scheduleFlush],
   );
 
-  const autoSave = useDebouncedCallback(saveScript, AUTOSAVE_DELAY);
+  useEffect(() => {
+    // 슬라이드 전환 시 이전 슬라이드 저장 상태를 초기화
+    activeSlideIdRef.current = slideId;
+    lastSavedRef.current = '';
+    pendingScriptRef.current = null;
+    isSavingRef.current = false;
+  }, [slideId]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      void flushPendingSave();
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [flushPendingSave]);
+
+  const flushSave = useCallback(() => {
+    void flushPendingSave();
+  }, [flushPendingSave]);
 
   return {
     autoSave,
+    flushSave,
     isSaving: isPending,
   };
 }


### PR DESCRIPTION
## Summary
- Harden script autosave for offline/reconnect gaps by queuing pending content and retrying on `online`
- Prevent stale server responses from overwriting in-progress local edits in slide workspace
- Improve responsiveness by reducing autosave debounce (500ms -> 300ms) and flushing on textarea blur
- Update script mutation cache handling to reduce race conditions
- Add tests for reconnect retry, immediate flush paths, and in-flight save handoff

## Verification
- npm test -- src/hooks/useAutoSaveScript.test.ts --maxWorkers=1
- npm run type-check
- npx eslint src/hooks/useAutoSaveScript.ts src/hooks/useAutoSaveScript.test.ts src/components/slide/SlideWorkspace.tsx src/hooks/queries/useScript.ts src/components/slide/script/ScriptBoxContent.tsx