### PR TITLE
fix: 시간 표기가 '방금 후'로 표기됨 (#295)

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -86,9 +86,9 @@ describe('formatRelativeTime', () => {
     expect(result).toContain('방금');
   });
 
-  it('normalizes future "just now" to past "just now"', () => {
-    const nearFuture = new Date(Date.now() + 30_000).toISOString();
-    expect(formatRelativeTime(nearFuture)).toBe('방금 전');
+  it('forces future server timestamps to be rendered as past based on client clock', () => {
+    const future = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(future)).toBe('방금 전');
   });
 
   it('returns original string for invalid dates', () => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -29,8 +29,12 @@ export function formatRelativeTime(date: string): string {
   const d = dayjs(date);
   if (!d.isValid()) return date;
 
-  const relative = d.fromNow();
-  return relative === '방금 후' ? '방금 전' : relative;
+  // 서버/클라이언트 시계 차이로 미래 시간이 들어와도 항상 과거 기준으로 렌더링한다.
+  const oneSecondAgo = dayjs().subtract(1, 'second');
+  const adjusted = d.subtract(1, 'second');
+  const effective = adjusted.isAfter(oneSecondAgo) ? oneSecondAgo : adjusted;
+
+  return effective.fromNow();
 }
 
 /**


### PR DESCRIPTION
## 📌 관련 이슈
- close #295

## ✨ 변경 내용
- 상대시간 계산 전에 서버 시간에 1초를 선보정했습니다.
- 선보정 후에도 클라이언트 현재 시각보다 미래라면 `현재-1초`로 클램프해 항상 과거 기준으로 표시되게 했습니다.
- 근미래(5분) 입력에서도 `방금 전`으로 렌더링되는 테스트를 추가했습니다.

## 💡 참고 사항
- 테스트: `npm run test -- src/utils/format.test.ts`
- 점검: `npx -y react-doctor@latest . --verbose --diff` (변경 파일 기준 이슈 없음)
