### PR TITLE
fix: 인사이트 화면 프로필 이미지 안뜸 (#290)

### DIFF
--- a/src/api/dto/analytics.dto.ts
+++ b/src/api/dto/analytics.dto.ts
@@ -176,6 +176,7 @@ export interface RecentCommentUserDto {
   nickName: string;
   name: string;
   profileImage?: string;
+  profileImageUrl?: string | null;
 }
 
 /**

--- a/src/components/insight/RecentCommentsSection.test.tsx
+++ b/src/components/insight/RecentCommentsSection.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { ReadRecentCommentListResponseDto } from '@/api/dto/analytics.dto';
+
+import { RecentCommentsSection } from './RecentCommentsSection';
+
+describe('RecentCommentsSection', () => {
+  it('uses profileImageUrl fallback when profileImage is missing', () => {
+    const recentCommentsData: ReadRecentCommentListResponseDto = {
+      comments: [
+        {
+          commentId: 'comment-1',
+          content: '좋은 발표였어요.',
+          timestampMs: 42000,
+          createdAt: '2026-02-01T00:00:00.000Z',
+          user: {
+            userId: 'user-1',
+            nickName: 'alex',
+            name: 'Alex',
+            profileImageUrl: 'https://example.com/avatar.png',
+          },
+          slide: {
+            slideId: 'slide-1',
+            slideNum: 1,
+            title: '첫 번째 슬라이드',
+            imageUrl: 'https://example.com/slide-1.png',
+          },
+        },
+      ],
+    };
+
+    render(<RecentCommentsSection hasVideo recentCommentsData={recentCommentsData} />);
+
+    expect(screen.getByRole('img', { name: 'Alex' })).toHaveAttribute(
+      'src',
+      'https://example.com/avatar.png',
+    );
+  });
+});

--- a/src/components/insight/RecentCommentsSection.tsx
+++ b/src/components/insight/RecentCommentsSection.tsx
@@ -68,7 +68,9 @@ export function RecentCommentsSection({
             <RecentCommentItem
               key={comment.commentId}
               user={comment.user.name}
-              userProfileImage={comment.user.profileImage}
+              userProfileImage={
+                comment.user.profileImage ?? comment.user.profileImageUrl ?? undefined
+              }
               slideLabel={comment.slide ? `슬라이드 ${comment.slide.slideNum}` : '전체'}
               time={formatVideoTimestamp(seconds)}
               text={comment.content}


### PR DESCRIPTION
## 📌 관련 이슈
- close #290

## ✨ 변경 내용
- 인사이트 최근 댓글 카드에서 `user.profileImage`가 없을 때 `user.profileImageUrl`을 fallback으로 사용하도록 수정했습니다.
- 최근 댓글 사용자 DTO에 `profileImageUrl?: string | null` 필드를 추가해 서버 응답 키와 호환되도록 맞췄습니다.
- `profileImage`가 없어도 아바타가 렌더링되는 회귀 테스트를 추가했습니다.

## 💡 참고 사항
- 테스트: `npm run test -- src/components/insight/RecentCommentsSection.test.tsx`
- 타입체크: `npm run type-check`
