### PR TITLE
fix: 불필요한 조건 분기 제거

### DIFF
--- a/src/pages/FeedbackSlidePage.tsx
+++ b/src/pages/FeedbackSlidePage.tsx
@@ -101,7 +101,7 @@ export default function FeedbackSlidePage({
               onGoToRef={handleGoToRef}
               onDeleteComment={deleteComment}
               onUpdateComment={updateComment}
-              isLoading={isLoading || isCommentsLoading}
+              isLoading={isCommentsLoading}
               hasNextPage={commentsHasNextPage}
               isFetchingNextPage={commentsIsFetchingNextPage}
               onLoadMore={commentsFetchNextPage}


### PR DESCRIPTION
In general, to fix a condition where part of a boolean expression is always false in a given control flow path, you should either refactor the control flow so that the variable can actually vary there, or remove the dead part of the condition and document the intended behavior. Here, the component already returns early while `isLoading` is true, so the subsequent JSX should treat `isLoading` as definitively false. We should therefore simplify the `CommentList` prop from `isLoading={isLoading || isCommentsLoading}` to `isLoading={isCommentsLoading}`, which both resolves the CodeQL finding and more accurately reflects that only the comment‑level loading state is relevant at that point.

Concretely, in `src/pages/FeedbackSlidePage.tsx`, locate the `CommentList` JSX block inside the desktop layout (around line 97–108). Change the `isLoading` prop so that it no longer depends on the page‑level `isLoading` and depends solely on `isCommentsLoading`. No new imports, functions, or types are needed; this is a one‑line change that does not alter other behavior, because `isLoading` is already guaranteed to be false whenever that JSX is rendered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._